### PR TITLE
Preserved quotes around values

### DIFF
--- a/ezini.js
+++ b/ezini.js
@@ -34,9 +34,6 @@ function parseSync(str) {
 				} else if (!isNaN(value)) {
 					// if value is a number
 					value = +value
-				} else {
-					// regard value as string
-					value = value.replace(/^"|"$/g, "")
 				}
 
 				if (section === null) {

--- a/ezini.js
+++ b/ezini.js
@@ -6,11 +6,11 @@ const os = require("os")
  * @param {string} str INI-format string
  * @returns {Object} Object parsed from the given string
  */
-function parseSync(str) {
+function parseSync(str, options = {}) {
 	const output = {}
 	let section = null
 	if (str.trim().length === 0) {
-		return 		{}
+		return {}
 	}
 	const lines = str.split(os.EOL)
 	lines.forEach((rawLine) => {
@@ -34,10 +34,12 @@ function parseSync(str) {
 				} else if (!isNaN(value)) {
 					// if value is a number
 					value = +value
+				} else if (!options.preserveQuotes) {
+					// regard value as string
+					value = value.replace(/^"|"$/g, "")
 				}
 
 				if (section === null) {
-					output[match[1].trim()] = match[2].trim().replace(/^"|"$/g, "")
 					output[key] = value
 				} else {
 					output[section][key] = value
@@ -55,9 +57,13 @@ function parseSync(str) {
  * @param callback Callback after parsing complete,
  *     should have one parameter: obj(the parsed object)
  */
-function parse(str, callback) {
+function parse(str, options, callback) {
+	if (typeof options === 'function') {
+		callback = options
+		options = {}
+	}
 	process.nextTick(() => {
-		const output = parseSync(str)
+		const output = parseSync(str, options)
 		callback(output)
 	})
 }


### PR DESCRIPTION
Since there is no standard INI format or best practices, people and projects may do whatever they want.  One thing a lot of projects do is use quotes to distinguish between things they treat as strings and things they treat as expressions or references.

That is, some projects support and encourage the following, where `"x"` is treated like a string, and `y` is treated like a... thing:

```ini
[whatever]
foo = "x"
bar = y
```

I propose that the handling of quotes be moved to user-land.

I realize that this change breaks current behavior in this case, and may perhaps be too jarring to consider.  But I wanted to open up the conversation and see what you think.  Do you think I should make it a parameter or config setting instead?

In case you are wondering, the project that led me to make this change is the Godot game engine.  It uses values like `ExtResource(1)`, which is not treated as a string, and distinguishes from strings by wrapping them in double quotes.  With this change, I hardcode double quotes where I need them.